### PR TITLE
Handle non-ASCII RD names

### DIFF
--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unicodedata
 
 sra_list = {
     "SRR32024533": "M. riyadhense",
@@ -258,6 +259,7 @@ for SRR in sra_list:
             debut = int(debut)
             fin = int(fin)
             nom = nom.rstrip(' ')
+            nom = unicodedata.normalize('NFKD', nom).encode('ascii', 'ignore').decode('ascii')
             nom = nom.replace(' ', '_').replace('/', '-')
             print(debut)
             print(fin)


### PR DESCRIPTION
## Summary
- normalize RD names to ASCII before writing FASTA headers

## Testing
- `python3 - <<'PY'
import unicodedata
s='RDbovis_Δpan'
print(unicodedata.normalize('NFKD', s).encode('ascii','ignore').decode())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6856925dd284832eb87ad3c76e7eb8e5