### PR TITLE
Add read preprocessing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# TB Investigator Utilities
+
+This repository provides small scripts used in tuberculosis genome analyses.
+
+## Preprocess reads
+
+`preprocess_reads.py` trims adapter sequences and filters low-quality reads
+using **cutadapt**. Install cutadapt and run the script before assembly to
+improve the quality of your data.
+
+### Installation
+
+```bash
+pip install cutadapt
+```
+
+### Usage
+
+```bash
+./preprocess_reads.py -1 sample_R1.fastq -2 sample_R2.fastq \
+    -o trimmed/sample --quality 20 --length 50 --threads 4
+```
+
+This will produce `trimmed/sample_1.fastq` and `trimmed/sample_2.fastq` with
+adapter sequences removed and low-quality bases trimmed.

--- a/preprocess_reads.py
+++ b/preprocess_reads.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Trim adapters and low-quality bases using cutadapt."""
+import argparse
+import subprocess
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Trim adapters and filter low-quality reads using cutadapt"
+    )
+    parser.add_argument(
+        "-1",
+        "--reads1",
+        required=True,
+        help="Input FASTQ file for read 1",
+    )
+    parser.add_argument(
+        "-2",
+        "--reads2",
+        help="Input FASTQ file for read 2 (optional)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-prefix",
+        required=True,
+        help="Prefix for the trimmed output FASTQ files",
+    )
+    parser.add_argument(
+        "--adapter-fwd",
+        default="AGATCGGAAGAGCACACGTCTGAACTCCAGTCA",
+        help="Adapter sequence for read 1",
+    )
+    parser.add_argument(
+        "--adapter-rev",
+        default="AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
+        help="Adapter sequence for read 2",
+    )
+    parser.add_argument(
+        "--quality",
+        type=int,
+        default=20,
+        help="Trim low-quality bases below this Phred score",
+    )
+    parser.add_argument(
+        "--length",
+        type=int,
+        default=50,
+        help="Discard reads shorter than this length after trimming",
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=4,
+        help="Number of threads to use",
+    )
+
+    args = parser.parse_args()
+
+    cmd = [
+        "cutadapt",
+        "-j",
+        str(args.threads),
+        "-q",
+        str(args.quality),
+        "-m",
+        str(args.length),
+        "-a",
+        args.adapter_fwd,
+    ]
+
+    if args.reads2:
+        cmd += ["-A", args.adapter_rev]
+
+    cmd += ["-o", f"{args.output_prefix}_1.fastq"]
+
+    if args.reads2:
+        cmd += ["-p", f"{args.output_prefix}_2.fastq", args.reads1, args.reads2]
+    else:
+        cmd += [args.reads1]
+
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `preprocess_reads.py` for trimming adapters and low quality bases with cutadapt
- document how to run the script in a new README

## Testing
- `python3 -m py_compile preprocess_reads.py`

------
https://chatgpt.com/codex/tasks/task_e_68569985bd00832e87cab6abd7fb90ee