### PR TITLE
Fix makeblastdb errors with non-ASCII headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ celles strictement inférieures à la longueur des lectures.
 Par exemple, pour des lectures de 150 nt, tous les k-mers précédents sont
 utilisés, alors que pour des lectures de 100 nt seuls `21,33,55,77,99` seront
 passés à SPAdes.
+
+Lors de la construction des bases de données de régions de délétions (RD),
+les en-têtes FASTA sont nettoyés pour supprimer les caractères spéciaux.
+Ceci évite les erreurs `makeblastdb` quand des symboles non ASCII comme `Δ`
+apparaissent dans les noms de séquences.


### PR DESCRIPTION
## Summary
- sanitize FASTA headers so that `makeblastdb` works with unicode
- document FASTA header sanitization in README

## Testing
- `python3 -m py_compile make_blastdb.py preprocess_reads.py`


------
https://chatgpt.com/codex/tasks/task_e_68594e429280832ead290b4e3f9402ae