### PR TITLE
Add new L5 strain

### DIFF
--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -254,6 +254,7 @@ sra_list = {
     "ERR017801": "L5",
     "ERR5336143": "L5",
     "ERR1082132": "L5",
+    "ERR12345": "L5",
     "SRR1239339": "Pinipedii",
     "SRR7693090": "Pinipedii",
     "ERR4627394": "Microti",


### PR DESCRIPTION
## Summary
- add ERR12345 to the list of L5 strains in `make_blastdb.py`

## Testing
- `python -m py_compile make_blastdb.py preprocess_reads.py`

------
https://chatgpt.com/codex/tasks/task_e_685d54124368832ebcc16a4665b62eda