### PR TITLE
Add GC content calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ Lors de la construction des bases de données de régions de délétions (RD),
 les en-têtes FASTA sont nettoyés pour supprimer les caractères spéciaux.
 Ceci évite les erreurs `makeblastdb` quand des symboles non ASCII comme `Δ`
 apparaissent dans les noms de séquences.
+
+## Calcul du taux de GC
+
+Le script `analyse_seq.py` calcule le pourcentage global de GC d'un fichier FASTA.
+
+### Usage
+
+```bash
+./analyse_seq.py sequences.fasta
+```
+
+Le pourcentage de GC est affiché sur la sortie standard avec deux décimales.

--- a/analyse_seq.py
+++ b/analyse_seq.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Compute GC content of a FASTA file."""
+import argparse
+
+
+def compute_gc(fasta: str) -> float:
+    """Return the overall GC percentage of all sequences in *fasta*."""
+    total_len = 0
+    gc_count = 0
+    seq = []
+    with open(fasta) as fh:
+        for line in fh:
+            if line.startswith('>'):
+                if seq:
+                    sequence = ''.join(seq).upper()
+                    gc_count += sequence.count('G') + sequence.count('C')
+                    total_len += len(sequence)
+                    seq = []
+            else:
+                seq.append(line.strip())
+        if seq:
+            sequence = ''.join(seq).upper()
+            gc_count += sequence.count('G') + sequence.count('C')
+            total_len += len(sequence)
+    if total_len == 0:
+        return 0.0
+    return gc_count / total_len * 100
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute GC content of a FASTA file"
+    )
+    parser.add_argument('fasta', help='Input FASTA file')
+    args = parser.parse_args()
+    gc = compute_gc(args.fasta)
+    print(f"{gc:.2f}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `analyse_seq.py` to compute GC content of FASTA files
- document the new script in the README

## Testing
- `python3 -m py_compile analyse_seq.py preprocess_reads.py make_blastdb.py`

------
https://chatgpt.com/codex/tasks/task_e_685e42e29580832e9a6f7b3e1b886100