### PR TITLE
Integrate Prodigal CDS listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ des phages ou des éléments transposables.
 
 ## Lister les CDS prédits par Prodigal
 
-Le script `list_cds.py` exécute Prodigal sur un fichier FASTA et affiche un
-résumé du nombre de CDS détectés ainsi que leur répartition par brin. Il écrit
-également les annotations au format GFF et les protéines traduites.
+`analyse_seq.py` peut également lancer Prodigal pour prédire les CDS et en
+afficher un résumé. Les annotations GFF et les protéines traduites sont écrites
+à l'emplacement spécifié par `--prodigal-prefix` (dans `--tmpdir` par défaut).
 
 ### Usage
 
 ```bash
-./list_cds.py genome.fasta -o resultat/prodigal
+./analyse_seq.py genome.fasta --list-cds --prodigal-prefix resultat/prodigal
 ```
 
 Les fichiers `resultat/prodigal.gff` et `resultat/prodigal.faa` contiendront

--- a/list_cds.py
+++ b/list_cds.py
@@ -1,67 +1,8 @@
 #!/usr/bin/env python3
 """Run Prodigal on a FASTA file and summarize predicted CDS."""
 import argparse
-import subprocess
 from typing import List, Dict
-
-
-def run_prodigal(fasta: str, prefix: str, mode: str = "meta") -> tuple[str, str]:
-    """Run prodigal and return paths to GFF and protein FASTA."""
-    gff = f"{prefix}.gff"
-    faa = f"{prefix}.faa"
-    subprocess.run([
-        "prodigal",
-        "-i",
-        fasta,
-        "-p",
-        mode,
-        "-a",
-        faa,
-        "-f",
-        "gff",
-        "-o",
-        gff,
-        "-q",
-    ], check=True)
-    return gff, faa
-
-
-def parse_gff(gff: str) -> List[Dict[str, str]]:
-    """Parse Prodigal GFF and return CDS info."""
-    cds = []
-    with open(gff) as fh:
-        for line in fh:
-            if line.startswith("#"):
-                continue
-            parts = line.strip().split("\t")
-            if len(parts) < 9:
-                continue
-            seqid, _source, type_, start, end, _score, strand, _phase, attrs = parts
-            if type_ != "CDS":
-                continue
-            attr_dict: Dict[str, str] = {}
-            for item in attrs.split(";"):
-                if "=" in item:
-                    key, value = item.split("=", 1)
-                    attr_dict[key] = value
-            cds.append({
-                "seqid": seqid,
-                "start": start,
-                "end": end,
-                "strand": strand,
-                "id": attr_dict.get("ID", ""),
-            })
-    return cds
-
-
-def summarize_cds(cds: List[Dict[str, str]]) -> None:
-    """Print a short summary of CDS."""
-    print(f"{len(cds)} CDS predicted")
-    strand_counts: Dict[str, int] = {}
-    for c in cds:
-        strand_counts[c["strand"]] = strand_counts.get(c["strand"], 0) + 1
-    for strand, count in strand_counts.items():
-        print(f"{count} CDS on strand {strand}")
+from analyse_seq import run_prodigal, parse_gff, summarize_cds
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- include Prodigal CDS prediction functions in `analyse_seq.py`
- allow running Prodigal from `analyse_seq.py` with `--list-cds`
- wrap `list_cds.py` around new shared functions
- document new usage in README

## Testing
- `python3 -m py_compile analyse_seq.py list_cds.py make_blastdb.py preprocess_reads.py`

------
https://chatgpt.com/codex/tasks/task_e_685ebae512b8832e9b468715b87d5694