### PR TITLE
Add support for multiple ORF BLAST databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,16 @@ afficher un résumé. Les annotations GFF et les protéines traduites sont écri
 
 Les fichiers `resultat/prodigal.gff` et `resultat/prodigal.faa` contiendront
 respectivement les coordonnées des CDS et leurs séquences protéiques.
+
+## Recherche de transposases par BLASTX
+
+L'option `--orf-search` prédit les ORF avec Prodigal puis interroge une ou
+plusieurs bases BLAST protéiques. Utilisez `--orf-db` plusieurs fois pour
+indiquer les bases à interroger.
+
+### Exemple
+
+```bash
+./analyse_seq.py genome.fasta --orf-search \
+    --orf-db myco_proteins --orf-db isfinder_prot
+```

--- a/analyse_seq.py
+++ b/analyse_seq.py
@@ -296,7 +296,12 @@ def main():
         help="Prédire les ORFs et faire une recherche de transposase",
     )
     parser.add_argument(
-        "--orf-db", help="Base BLAST protéines (e.g. NR ou ISFinder_proteins)"
+        "--orf-db",
+        action="append",
+        help=(
+            "Base BLAST protéines (e.g. NR ou ISFinder_proteins). "
+            "Peut être spécifiée plusieurs fois."
+        ),
     )
     parser.add_argument(
         "--hmmer", action="store_true", help="Faire aussi une recherche HMMER/PFAM"
@@ -386,16 +391,18 @@ def main():
         print("\nRecherche de transposases ou intégrases par annotation ORF/blastx :")
         faa = predict_orfs(args.fasta, os.path.join(args.tmpdir, "orfs"))
         if args.orf_db:
-            try:
-                hits = blastx_hits(faa, args.orf_db, args.evalue)
-                if hits:
-                    print("Hits transposase/integrase trouvés (blastp) :")
-                    for h in hits:
-                        print(h)
-                else:
-                    print("Aucun hit transposase/integrase (blastp).")
-            except RuntimeError as err:
-                print(err)
+            for db in args.orf_db:
+                print(f"\nRecherche dans la base {db} :")
+                try:
+                    hits = blastx_hits(faa, db, args.evalue)
+                    if hits:
+                        print("Hits transposase/integrase trouvés (blastp) :")
+                        for h in hits:
+                            print(h)
+                    else:
+                        print("Aucun hit transposase/integrase (blastp).")
+                except RuntimeError as err:
+                    print(err)
         if args.hmmer and args.pfam_db:
             try:
                 hits = run_hmmer(faa, args.pfam_db)


### PR DESCRIPTION
## Summary
- allow repeating `--orf-db` option to query several protein databases
- display results for each database
- document the new feature in README

## Testing
- `python3 -m py_compile analyse_seq.py preprocess_reads.py make_blastdb.py list_cds.py`

------
https://chatgpt.com/codex/tasks/task_e_685ec0c90768832e96bcd015faf5a479