### PR TITLE
Add generic ORF search

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ afficher un résumé. Les annotations GFF et les protéines traduites sont écri
 Les fichiers `resultat/prodigal.gff` et `resultat/prodigal.faa` contiendront
 respectivement les coordonnées des CDS et leurs séquences protéiques.
 
-## Recherche de transposases par BLASTX
+## Recherche de protéines par BLASTX
 
 L'option `--orf-search` prédit les ORF avec Prodigal puis interroge une ou
 plusieurs bases BLAST protéiques. Utilisez `--orf-db` plusieurs fois pour
-indiquer les bases à interroger.
+indiquer les bases à interroger. Par défaut, seuls les hits contenant le mot
+clé "transposase" sont affichés. Vous pouvez spécifier un autre mot-clé avec
+`--orf-keyword` ou désactiver le filtrage en passant `--orf-keyword none`.
 
 ### Exemple
 


### PR DESCRIPTION
## Summary
- allow analysing ORFs for any protein keyword
- expose `--orf-keyword` option
- update BLAST/HMMER filtering logic and messages
- document ORF keyword filtering in README

## Testing
- `python3 -m py_compile analyse_seq.py list_cds.py preprocess_reads.py make_blastdb.py`

------
https://chatgpt.com/codex/tasks/task_e_685ec2567fbc832e82823178cc93661f