### PR TITLE
Simplify ORF search output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ respectivement les coordonnées des CDS et leurs séquences protéiques.
 L'option `--orf-search` prédit les ORF avec Prodigal puis interroge une ou
 plusieurs bases BLAST protéiques. Utilisez `--orf-db` plusieurs fois pour
 indiquer les bases à interroger. Par défaut, seuls les hits contenant le mot
-clé "transposase" sont affichés. Vous pouvez spécifier un autre mot-clé avec
-`--orf-keyword` ou désactiver le filtrage en passant `--orf-keyword none`.
+clé "transposase" sont résumés. Le script indique pour chaque ORF le meilleur
+hit trouvé. Utilisez l'option `--orf-detailed` pour obtenir la sortie BLAST
+complète. Vous pouvez spécifier un autre mot-clé avec `--orf-keyword` ou
+désactiver le filtrage en passant `--orf-keyword none`.
 
 ### Exemple
 


### PR DESCRIPTION
## Summary
- add function to count FASTA entries
- parse BLAST output and summarize best hits per ORF
- show summary of ORF search with optional detailed lines via `--orf-detailed`
- mention new summary behaviour in README

## Testing
- `python -m py_compile analyse_seq.py list_cds.py make_blastdb.py preprocess_reads.py`

------
https://chatgpt.com/codex/tasks/task_e_685fa74262d0832ea12a5be8b6f0077f