### PR TITLE
Add hmmscan e-value and detailed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,8 @@ désactiver le filtrage en passant `--orf-keyword none`.
 ./analyse_seq.py genome.fasta --orf-search \
     --orf-db myco_proteins --orf-db isfinder_prot
 ```
+
+Une recherche de domaines PFAM peut être ajoutée en indiquant `--hmmer` et la
+base `--pfam-db`. Le seuil de recherche est contrôlé par `--evalue`, utilisé
+aussi bien pour BLAST que pour HMMER. L'option `--orf-detailed` affiche alors
+les lignes complètes des résultats.


### PR DESCRIPTION
## Summary
- support setting e-value threshold for hmmscan
- print PFAM hits when `--orf-detailed` is used
- document HMMER usage and the `--evalue` option

## Testing
- `python3 -m py_compile analyse_seq.py list_cds.py preprocess_reads.py make_blastdb.py`
- `python3 analyse_seq.py -h`

------
https://chatgpt.com/codex/tasks/task_e_685fe57ca478832eae5a789be188fb4e