### PR TITLE
Add eggnog-mapper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,8 @@ Une recherche de domaines PFAM peut être ajoutée en indiquant `--hmmer` et la
 base `--pfam-db`. Le seuil de recherche est contrôlé par `--evalue`, utilisé
 aussi bien pour BLAST que pour HMMER. L'option `--orf-detailed` affiche alors
 les lignes complètes des résultats.
+
+Pour une annotation fonctionnelle plus complète, activez `--eggnog` pour lancer
+`eggnog-mapper` sur les protéines prédites. Utilisez `--eggnog-data` pour
+spécifier le répertoire de données et `--eggnog-cpu` pour ajuster le nombre de
+threads.


### PR DESCRIPTION
## Summary
- run eggnog-mapper on predicted ORFs when --eggnog is set
- parse eggnog annotations
- expose new CLI options for eggnog-mapper
- print eggnog results in ORF details
- document eggnog usage in README

## Testing
- `python -m py_compile analyse_seq.py preprocess_reads.py list_cds.py make_blastdb.py`
- `emapper.py --help | head -n 5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f1434bf8832e9a1f102bf8ee2318