### PR TITLE
Calcule la moyenne des couvertures BLASTn

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Le pourcentage de GC est affiché sur la sortie standard avec deux décimales.
 Si vous disposez de bases BLAST par sous-lignée (dans un répertoire `bdd/` par
 exemple), le script peut afficher un arbre phylogénétique ASCII indiquant pour
 chaque feuille le pourcentage de la séquence retrouvée dans la base
-correspondante :
+correspondante. Lorsque plusieurs séquences sont fournies via `--filename`,
+les pourcentages sont la moyenne calculée sur l'ensemble de ces entrées :
 
 ```bash
 ./analyse_seq.py sequences.fasta --lineage-db-dir bdd

--- a/analyse_seq.py
+++ b/analyse_seq.py
@@ -1105,12 +1105,15 @@ def main():
         coverages: Dict[str, float] = {}
         for leaf in tree.iter_leaves():
             db_prefix = os.path.join(args.lineage_db_dir, leaf.name)
-            try:
-                pct = blast_coverage(args.fasta, db_prefix, args.evalue)
-            except RuntimeError as err:
-                print(err)
-                pct = 0.0
-            coverages[leaf.name] = pct
+            values = []
+            for fasta in selected_fastas:
+                try:
+                    pct = blast_coverage(fasta, db_prefix, args.evalue)
+                except RuntimeError as err:
+                    print(err)
+                    pct = 0.0
+                values.append(pct)
+            coverages[leaf.name] = sum(values) / len(values) if values else 0.0
         for leaf in tree.iter_leaves():
             pct = coverages.get(leaf.name, 0.0)
             leaf.name = f"{leaf.name} ({pct:.1f}%)"


### PR DESCRIPTION
## Summary
- calcule la moyenne des couvertures BLASTn sur toutes les séquences fournies
- documente le comportement dans le README

## Testing
- `python -m py_compile analyse_seq.py`

------
https://chatgpt.com/codex/tasks/task_e_68614dd07418832ea1ff7209205a98f3