### PR TITLE
Improve tRNAscan error reporting

### DIFF
--- a/analyse_seq.py
+++ b/analyse_seq.py
@@ -609,8 +609,9 @@ def run_trnascan(fasta: str, trnascan: str, outdir: str) -> List[Dict[str, Any]]
             f"{trnascan} not found. Install tRNAscan-SE to use this option."
         ) from exc
     except subprocess.CalledProcessError as exc:
+        error_output = exc.stdout + (exc.stderr or "")
         raise RuntimeError(
-            f"tRNAscan-SE failed with status {exc.returncode}:\n{exc.stdout}"
+            f"tRNAscan-SE failed with status {exc.returncode}:\n{error_output}"
         ) from exc
 
     features: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- surface tRNAscan stderr when execution fails

## Testing
- `python -m py_compile analyse_seq.py`


------
https://chatgpt.com/codex/tasks/task_e_68616980a418832e8b52e80393ace1bf