### PR TITLE
Fix blastdbcmd entry retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ des phages ou des éléments transposables.
   BLAST :
 
   ```bash
-  makeblastdb -in plsdb.fasta -dbtype nucl -out plsdb_db
+  makeblastdb -in plsdb.fasta -dbtype nucl -out plsdb_db -parse_seqids
   ```
 
 - **PHASTER** permet l'analyse de séquences phagiques en ligne sur
@@ -101,6 +101,8 @@ des phages ou des éléments transposables.
 Une base BLAST de séquences spécifiques de *M. tuberculosis* peut être placée
 dans `bdd/mydb`. Le script la consulte automatiquement pour la séquence
 analysée et pour chaque ORF détecté :
+Assurez-vous que cette base a été construite avec l'option `-parse_seqids` afin
+de pouvoir récupérer des entrées par leur nom.
 
 ```bash
 ./analyse_seq.py genome.fasta --tb-db bdd/mydb

--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -85,7 +85,11 @@ def analyze_absent_regions(srr: str, bam: str, h37rv_fasta: str, rd_dir: str,
 
     # Prepare RD database
     build_rd_fasta(rd_dir, rd_fasta)
-    subprocess.run(f"makeblastdb -in {rd_fasta} -dbtype nucl -out {blast_db}", shell=True, check=True)
+    subprocess.run(
+        f"makeblastdb -in {rd_fasta} -dbtype nucl -out {blast_db} -parse_seqids",
+        shell=True,
+        check=True,
+    )
     subprocess.run(
         f"blastn -query {absent_fasta} -db {blast_db} "
         "-outfmt '6 qseqid sseqid pident length bitscore evalue qstart qend sstart send' "
@@ -342,7 +346,7 @@ def update_lineage_db(srr: str, lineage: str, mapped: str, unmapped: str) -> Non
         )
 
     subprocess.run(
-        f"makeblastdb -in {fasta_path} -dbtype nucl -out bdd/{clean}",
+        f"makeblastdb -in {fasta_path} -dbtype nucl -out bdd/{clean} -parse_seqids",
         shell=True,
         check=True,
     )
@@ -480,7 +484,9 @@ for SRR in [u for u in sra_list if u not in done]:
             concat(f"data/RD/{nom}.fasta")
         
 
-    os.system(f"makeblastdb -in data/all_contigs.fasta -dbtype nucl -out bdd/mydb")
+    os.system(
+        "makeblastdb -in data/all_contigs.fasta -dbtype nucl -out bdd/mydb -parse_seqids"
+    )
     done.append(SRR)
     with open('done.pkl', 'wb') as f:
         pickle.dump(done, f)


### PR DESCRIPTION
## Summary
- update all `makeblastdb` calls to include `-parse_seqids`
- document use of `-parse_seqids` when building BLAST databases

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68625c2920f4832eac2f83c5a4258e35