### PR TITLE
Fix duplicate RD fasta headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ passés à SPAdes.
 
 Lors de la construction des bases de données de régions de délétions (RD),
 les en-têtes FASTA sont nettoyés pour supprimer les caractères spéciaux.
-Ceci évite les erreurs `makeblastdb` quand des symboles non ASCII comme `Δ`
-apparaissent dans les noms de séquences.
+Les noms dupliqués sont également renommés automatiquement pour garantir
+des identifiants uniques et éviter les erreurs de type `duplicate seq_ids`
+lors de l'exécution de `makeblastdb`. Les caractères non ASCII comme `Δ`
+ou les espaces sont ainsi éliminés et les doublons reçoivent un suffixe
+numéroté.
 
 La base BLAST finale est écrite dans le répertoire `bdd/` sous le nom
 `mydb` pour éviter de créer des fichiers à la racine du projet.

--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -85,6 +85,7 @@ def build_rd_fasta(rd_dir: str, rd_fasta: str) -> None:
     """Concatenate all RD FASTA files found in ``rd_dir``.
     Headers are sanitized to avoid non-ASCII characters."""
 
+    counts = {}
     with open(rd_fasta, "w") as out:
         for fname in sorted(os.listdir(rd_dir)):
             if not fname.endswith(".fasta"):
@@ -95,7 +96,10 @@ def build_rd_fasta(rd_dir: str, rd_fasta: str) -> None:
                 for line in fh:
                     last = line
                     if line.startswith(">"):
-                        clean = sanitize_header(line[1:].strip())
+                        base = sanitize_header(line[1:].strip())
+                        idx = counts.get(base, 0)
+                        counts[base] = idx + 1
+                        clean = base if idx == 0 else f"{base}_{idx+1}"
                         out.write(f">{clean}\n")
                     else:
                         out.write(line)


### PR DESCRIPTION
## Summary
- ensure unique sequence headers when building RD database
- document automatic renaming of duplicate RD headers

## Testing
- `python -m py_compile make_blastdb.py`

------
https://chatgpt.com/codex/tasks/task_e_6862a3f91e14832eaf39fc4b85e3f1d2