### PR TITLE
Fix duplicate BLAST identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ lors de l'exécution de `makeblastdb`. Les caractères non ASCII comme `Δ`
 ou les espaces sont ainsi éliminés et les doublons reçoivent un suffixe
 numéroté.
 
+Lors de la mise à jour des bases BLAST par sous-lignée, les noms de
+ligneages sont eux aussi "nettoyés" en remplaçant notamment les espaces
+par des underscores afin que chaque contig ajouté possède un identifiant
+unique compris par `makeblastdb`.
+
 La base BLAST finale est écrite dans le répertoire `bdd/` sous le nom
 `mydb` pour éviter de créer des fichiers à la racine du projet.
 

--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -378,6 +378,7 @@ def update_lineage_db(srr: str, lineage: str, mapped: str, unmapped: str) -> Non
 
     clean = lineage.replace(" ", "")
     fasta_path = os.path.join("bdd", f"{clean}.fasta")
+    header_lineage = sanitize_header(lineage)
 
     existing = ""
     if os.path.exists(fasta_path):
@@ -389,13 +390,13 @@ def update_lineage_db(srr: str, lineage: str, mapped: str, unmapped: str) -> Non
             unmapped,
             fasta_path,
             motif_source=">NODE_",
-            motif_cible=f">{srr}_{lineage}_unmapped_NODE_",
+            motif_cible=f">{srr}_{header_lineage}_unmapped_NODE_",
         )
         append_to_fasta(
             mapped,
             fasta_path,
             motif_source=">NODE_",
-            motif_cible=f">{srr}_{lineage}_mapped_NODE_",
+            motif_cible=f">{srr}_{header_lineage}_mapped_NODE_",
         )
 
     subprocess.run(


### PR DESCRIPTION
## Summary
- fix duplicate FASTA headers when adding contigs to lineage databases
- document header sanitization for lineage databases

## Testing
- `python -m py_compile make_blastdb.py`

------
https://chatgpt.com/codex/tasks/task_e_6862c3209c10832eaa981afa6cd68488