### PR TITLE
Fix duplicate seq id errors in BLAST DB creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ lors de l'exécution de `makeblastdb`. Les caractères non ASCII comme `Δ`
 ou les espaces sont ainsi éliminés et les doublons reçoivent un suffixe
 numéroté.
 
+Cette étape de normalisation et de déduplication est aussi appliquée lors
+de la mise à jour des bases BLAST par sous-lignée afin d'éviter toute
+collision d'identifiants.
+
 Lors de la mise à jour des bases BLAST par sous-lignée, les noms de
 ligneages sont eux aussi "nettoyés" en remplaçant notamment les espaces
 par des underscores afin que chaque contig ajouté possède un identifiant


### PR DESCRIPTION
## Summary
- ensure sequence headers are unique when building lineage BLAST databases
- document deduplication step in README

## Testing
- `python -m py_compile make_blastdb.py analyse_seq.py preprocess_reads.py list_cds.py`
- `python analyse_seq.py --help` *(fails: `ModuleNotFoundError: No module named 'numpy'`)*

------
https://chatgpt.com/codex/tasks/task_e_686375fc9828832ebd4887fa64f33ec6