### PR TITLE
Fix duplicate FASTA headers for final BLAST DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ unique compris par `makeblastdb`.
 
 La base BLAST finale est écrite dans le répertoire `bdd/` sous le nom
 `mydb` pour éviter de créer des fichiers à la racine du projet.
+Avant cette étape finale, les en-têtes de `data/all_contigs.fasta` sont
+également nettoyés et dédupliqués pour garantir l'absence de conflits
+`makeblastdb`.
 
 ## Calcul du taux de GC
 

--- a/make_blastdb.py
+++ b/make_blastdb.py
@@ -614,6 +614,9 @@ for SRR in [u for u in sra_list if u not in done]:
             concat(f"data/RD/{nom}.fasta")
         
 
+    # Sanitize headers and ensure unique identifiers before creating the
+    # consolidated BLAST database
+    deduplicate_fasta("data/all_contigs.fasta")
     os.system(
         "makeblastdb -in data/all_contigs.fasta -dbtype nucl -out bdd/mydb -parse_seqids"
     )


### PR DESCRIPTION
## Summary
- deduplicate headers when creating the consolidated database
- document the deduplication step in the README

## Testing
- `python -m py_compile analyse_seq.py list_cds.py make_blastdb.py preprocess_reads.py`

------
https://chatgpt.com/codex/tasks/task_e_68638c0a15bc832eb8cc65dea96425e3